### PR TITLE
Local Build Process: Take out the bumps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+run:
+	@jekyll serve --config _config.yml,_config_local.yml --baseurl '' --watch --verbose

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ If you want more information on getting started with Ruby development, STOP RIGH
 
 ## Local development and hacking
 
-In order to run this website in your local environment, you will need to have **Jekyll** serve it. GitHub Pages (the host of [codefortucson.org](codefortucson.org)) has some strange requirements on the base URL for its sites. Before we can run and test locally, we need to overwrite the corresponding settings. Thankfully, we can do this by simply appending the local development config file to the **Jekyll** command.
+In order to run this website in your local environment, you will need to have **Jekyll** serve it. GitHub Pages (the host of [codefortucson.org](codefortucson.org)) has some strange requirements on the base URL for its sites. Before we can run and test locally, we need to overwrite the corresponding settings. Thankfully, we can do this by simply appending the local development config file to the **Jekyll** command, which is done for you already in the **Makefile**.
 
 ```bash
-jekyll serve --config _config.yml,_config_local.yml --baseurl '' --watch
+make
 ```
+
+That's all it takes! Now you have a running Jekyll server on your local machine that will automatically watch for changes to the source files and update accordingly in response.
 
 _If you are using RVM, make sure you are using the correct Gemset!_
     

--- a/README.md
+++ b/README.md
@@ -26,38 +26,34 @@ We depend on a few Ruby gems:
 * [Kramdown](http://kramdown.gettalong.org)
 * [SASS](http://sass-lang.com)
 
-You should be able to install them via [RubyGems](https://rubygems.org):
+You should be able to install them via [RubyGems](https://rubygems.org). GitHub has built a meta package which pulls in all of these dependencies:
 
-    $ gem install jekyll kramdown sass
+    $ gem install github-pages
 
 If you want more information on getting started with Ruby development, STOP RIGHT THERE.  Use RVM instead.  If you're still using Ruby in 6 months, you'll thank us profusely.
 
-##Hacking
+## Local development and hacking
 
-###Update the configuration files
+In order to run this website in your local environment, you will need to have **Jekyll** serve it. GitHub Pages (the host of [codefortucson.org](codefortucson.org)) has some strange requirements on the base URL for its sites. Before we can run and test locally, we need to overwrite the corresponding settings. Thankfully, we can do this by simply appending the local development config file to the **Jekyll** command.
 
-Look for the `url` key in `_config.yml`.  Uncomment the local development line before starting local development, and **please remember to comment it back out before submitting pull requests**.
-
-Look for the `$site-baseurl` variable in [`assets/_sass/_custom.scss`](https://github.com/colinsf/cft-jekyll-site/blob/master/assets/_sass/_custom.scss#L6).
-
-###Run `jekyll`
+```bash
+jekyll serve --config _config.yml,_config_local.yml --baseurl '' --watch
+```
 
 _If you are using RVM, make sure you are using the correct Gemset!_
     
     $ rvm use 2.0.0@codefortucson
 
-Start the local web server
-
-    $ jekyll serve -b '' -w
-
-You should now be able to visit http://localhost:4000/ in your browser and see a copy of the Code for Tucson site hosted on your very own computer that updates when you save something! Zoiks!
+You should now be able to visit [http://localhost:4000/](http://localhost:4000/) in your browser and see a copy of the Code for Tucson site hosted on your very own computer that updates when you save something! Zoiks!
 
 ###To make changes:
-+ You should set up a fork of the site and test your changes there before submitting a pull request.
-+ Please work against the `master` branch.  `master == staging`.
-+ The production website is hosted off of the `gh-pages` branch.  You shouldn't work against this, but when you have publication-ready changes in `master`, you can pull those across to `gh-pages` to make them live. This enables people to work against a shared `master` branch without needing to ensure production-ready commits.
-+ If you have questions about contributing to an upstream repository with Github's fork workflow, read more on [forking repos](https://help.github.com/articles/fork-a-repo) and [syncing forks](https://help.github.com/articles/syncing-a-fork).
++ Clone the repository on your computer with `git clone [https or ssh repo url]`. You can find this on GitHub as the **Clone URL**.
++ Create a new branch to work on your addition, bug-fix, or feature with `git checkout -b [name of new branch]`. Try to use names that describe what you are accomplishing, such as `add/hackathon-project-info`, `fix/wrong-meeting-time`, or `new/funny-cat-video-page`.
++ Always leave [useful commit messages](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message). Taking the time to explain your changes will help you to better understand your work and will prevent accidental mishaps.
++ When you beieve that your changes are ready for production, create a pull request with a thorough description of the changes. Include before and after screenshots or testing instructions so that someone can review the changes before merging into `master`.
++ If you accidentally merge into `master`, it's okay - GitHub renders the site from the `gh-pages` branch. Only stable releases from `master` should ever be merged into `gh-pages`.
 
+Getting started with **git** can be confusing if you haven't worked with it before. If this describes how you feel, check out [a non-programmers intro to **git**](http://blog.scottlowe.org/2015/01/14/non-programmer-git-intro/), then [the simple guide](http://rogerdudler.github.io/git-guide/) for an overview of a **git** workflow, and Code School's [interactive **git** tutorial](https://try.github.io/levels/1/challenges/1).
 
 <!-- ###Special pages:
 + Press page uses /data/press.csv to populate its press listing (but not the press releases, which are hard-coded)

--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,8 @@ sass:
 
 baseurl: http://codefortucson.github.io/codefortucson-site
 url: http://www.codefortucson.org
-#uncomment when working locally
-#url:  http://localhost:4000/
 
 kramdown:
   parse_block_html: true
+
+production: true

--- a/_config_local.yml
+++ b/_config_local.yml
@@ -1,0 +1,4 @@
+baseurl: /codefortucson-site
+url:  http://localhost:4000/
+
+production: false

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -4,10 +4,6 @@
 
 $cft-light-green: #B8E986;
 $cft-dark-green: #437708;
-// Change this value for gh-pages hosting in a directory
-$site-baseurl: "/codefortucson-site";
-//$site-baseurl: "";
-
 
 /***************************/
 /*  general/sitewide */

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -10,7 +10,7 @@
 other styles here
 */
 
-
+$site-baseurl: '{{ site.baseurl }}';
 
 /*
 custom styles


### PR DESCRIPTION
When I started to try and get this site going on my machine I discovered
that it's pretty hard to setup correctly. A few of the issues with
hosting on GitHub Pages and Jekyll collided leading to some funky
instructions for doing local dev: commenting out variables in the build
config and also in CSS files. This process was a bit fragile with
regards to accidentally deploying changes that could take down the
production site.

Now, the build process has changed by the introduction of some
automatic variables that setup the environment in place of the
developer.

 + If the changes are accidentally deployed, they will reflect the
proper production environment.
 + Building locally required appending a local config file to the Jekyll
process: `jekyll serve --config _config.yml, _config_local.yml --baseurl ''
--watch`
 + The appropriate base url for CSS purposes has been moved to a
template variable in `style.css`
 + There is a new template variable, `production`, available which holds
`true` for production builds and `false` for development builds, as
specified by the inclusion of the local config file.

The local config file does not replace `_config.yml`, but merely
redefines a few variables, so both are needed.

I have also updated `README.md` to reflect these changes. Along the way
there were a few updates, such as using the `github-pages` **gem**
instead of installing all the dependencies separately.

Additionally I have linked some **git** tutorials in case this is all
very unfamiliar to some contributors.