### PR TITLE
Fixes a few persistent style issues

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -27,9 +27,9 @@
       </ul>
 
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://www.facebook.com/groups/codefortucson"><i class="fa fa-facebook-square">&nbsp;</i>Code for Tucson</a></li>
-        <li><a href="https://twitter.com/CodeforTucson"><i class="fa fa-twitter">&nbsp;</i>@CodeforTucson</a></li>
-        <li><a href="mailto:codefortucson@gmail.org"><i class="fa fa-envelope">&nbsp;</i>codefortucson@gmail.com</a></li>
+        <li><a href="https://www.facebook.com/groups/codefortucson"><i class="fa fa-facebook-square"></i></a></li>
+        <li><a href="https://twitter.com/CodeforTucson"><i class="fa fa-twitter"></i></a></li>
+        <li><a href="mailto:codefortucson@gmail.org"><i class="fa fa-envelope"></i></a></li>
       </ul>
 
     </div><!--/.nav-collapse -->

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -21,7 +21,7 @@
             <li {% if page.slug == 'code-of-conduct' %}{{ activeClass }}{% endif %}><a href="/code-of-conduct/">Code of Conduct</a></li>
           </ul>
         </li>
-        <li {% if page.slug == 'calendar' %}{{ activeClass }}{% endif %}><a href="/calendar/">Calendar</a></li>
+        <li {% if page.slug == 'calendar' %}{{ activeClass }}{% endif %}><a href="http://www.meetup.com/Code-for-Tucson/">Calendar</a></li>
         <li {% if page.slug == 'talk' %}{{ activeClass }}{% endif %}><a href="/talk/">Talk</a></li>
         <li {% if page.slug == 'projects' %}{{ activeClass }}{% endif %}><a href="/projects/">Projects</a></li>
       </ul>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -21,7 +21,7 @@
             <li {% if page.slug == 'code-of-conduct' %}{{ activeClass }}{% endif %}><a href="/code-of-conduct/">Code of Conduct</a></li>
           </ul>
         </li>
-        <li {% if page.slug == 'calendar' %}{{ activeClass }}{% endif %}><a href="http://www.meetup.com/Code-for-Tucson/">Calendar</a></li>
+        <li {% if page.slug == 'calendar' %}{{ activeClass }}{% endif %}><a href="http://www.meetup.com/Code-for-Tucson/" target="_blank">Calendar</a></li>
         <li {% if page.slug == 'talk' %}{{ activeClass }}{% endif %}><a href="/talk/">Talk</a></li>
         <li {% if page.slug == 'projects' %}{{ activeClass }}{% endif %}><a href="/projects/">Projects</a></li>
       </ul>

--- a/_layouts/subpage.html
+++ b/_layouts/subpage.html
@@ -3,7 +3,7 @@
   <head>
 
     {% include head.html %}
-    
+
   </head>
 
   <body>
@@ -11,15 +11,17 @@
     {% include navbar.html %}
 
     <div class="col-lg-12 hero">
-			<div class="hero-text"><img src="{{ site.baseurl }}/assets/images/CodeForTucson_logo_dark.png" 
+			<div class="hero-text"><img src="{{ site.baseurl }}/assets/images/CodeForTucson_logo_dark.png"
 			 alt="Code for Tucson logo"><h1>Code for Tucson</h1></div>
 		</div>
 
 		<div class="container center-home">
 
 			<div class="row">
-				<h1 class="h0">{{ page.title }}</h1>
-    
+        <div class="col-lg-8 subpage-title">
+				  <h1 class="h0">{{ page.title }}</h1>
+        </div>
+
     		{{ content }}
 
     	</div>

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -90,6 +90,10 @@ h1.h0 {
     }
 }
 
+.subpage-title {
+  margin-bottom: 35px;
+}
+
 .embed-container {
     position: relative;
     padding-bottom: 56.25%;

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -42,7 +42,7 @@ a {
 
 h1.h0 {
     font-size: 59px;
-    font-weight: bold;   
+    font-weight: bold;
     margin-top: 10px;
     padding-top: 20px;
     margin-bottom: 0;
@@ -56,7 +56,7 @@ h1.h0 {
     a {
         text-decoration: none;
     }
-    
+
     .dropdown:hover .dropdown-menu {
         display: block;
     }
@@ -115,20 +115,42 @@ height: 100%;
 .hero {
     background: url($site-baseurl + '/assets/images/hero_bg_op.jpg');
     background-size: cover;
-    min-height: 300px;
+    min-height: 200px;
     min-width: 400px;
-    padding: 0;
+    padding-top: 25px;
 }
 
 .hero-text {
     text-align: left;
-    padding-left: 15%;
-    margin-top: 25px;
 }
 
 .hero-text img {
-    height: 200px;
+    height: 90px;
     padding: 15px;
+}
+
+@media (min-width:464px){
+  .hero-text {
+    padding-left: 20%;
+
+    img {
+        height: 120px;
+    }
+  }
+}
+
+@media (min-width:764px){
+  .hero {
+      min-height: 300px;
+  }
+
+  .hero-text {
+    padding-left: 15%;
+
+    img {
+        height: 200px;
+    }
+  }
 }
 
 .hero-text h1 {
@@ -232,7 +254,7 @@ img.project-git-human {
 }
 
 #project-list h3,
-#press-list h3 { 
+#press-list h3 {
     margin-top:0;
     margin-bottom:5px;
 }
@@ -412,7 +434,7 @@ img.project-git-human {
     background-color: lighten($cft-light-green, 10%);
     padding: 20px 20px 30px 20px;
     margin-top: 20px;
-    li {  
+    li {
       list-style-type: none;
       padding-bottom: 8px;
     }

--- a/pages/index.html
+++ b/pages/index.html
@@ -49,7 +49,7 @@ slug: home
 		<h2 class="blackish">what we're doing</h2>
 		<p class='lead'>Code for Tucson creates tools, information, and experiences that serve the Old Pueblo. <br/>See a sample of our projects below, or <a href="/projects/">browse the complete list here.</a> You are welcome to dive right in!</p>
 
-	  {% for project in site.data.projects limit:2 %}
+	  {% for project in site.data.projects limit:3 %}
 	      <article class="projects row">
 
 	      	<div class="col-lg-4">

--- a/pages/index.html
+++ b/pages/index.html
@@ -25,7 +25,7 @@ slug: home
 
 			<h2><img src="{{ site.baseurl }}/assets/images/captain.png" alt="Code for America Brigade Captain Helmet" class="call-out-img" />Come to our next meeting</h2>
 			<p>First and third Tuesdays. Casual meetups for geeks, activists, policy makers, and journalists.</p>
-			<p><a href="http://www.meetup.com/Code-for-Tucson/">Our calendar &raquo;</a></p>
+			<p><a href="http://www.meetup.com/Code-for-Tucson/" target="_blank">Our calendar &raquo;</a></p>
 		</div>
 
 		<div class="col-lg-4">

--- a/pages/index.html
+++ b/pages/index.html
@@ -6,7 +6,7 @@ slug: home
 ---
 
 <div class="col-lg-12 hero">
-	<div class="hero-text"><img src="{{ site.baseurl }}/assets/images/CodeForTucson_logo_dark.png" 
+	<div class="hero-text"><img src="{{ site.baseurl }}/assets/images/CodeForTucson_logo_dark.png"
 	 alt="Code for Tucson logo"><h1>Code for Tucson</h1></div>
 </div>
 
@@ -22,10 +22,10 @@ slug: home
 	<div class="row">
 
 		<div class="col-lg-4">
-			
+
 			<h2><img src="{{ site.baseurl }}/assets/images/captain.png" alt="Code for America Brigade Captain Helmet" class="call-out-img" />Come to our next meeting</h2>
 			<p>First and third Tuesdays. Casual meetups for geeks, activists, policy makers, and journalists.</p>
-			<p><a href="/calendar/">Our calendar &raquo;</a></p>
+			<p><a href="http://www.meetup.com/Code-for-Tucson/">Our calendar &raquo;</a></p>
 		</div>
 
 		<div class="col-lg-4">
@@ -43,7 +43,7 @@ slug: home
     </div>
 
 	</div>
-		
+
 	<div class="row heading-stripe stuff-weve-made-stripe">
 
 		<h2 class="blackish">what we're doing</h2>


### PR DESCRIPTION
- Removes words from social media in navbar because tl;dr, and then it displays better on smaller screen sizes, too
- Changes 'calendar' links on nav and homepage from a subpage with an iframed google cal, to our meetup site
- Changes number of projects displayed on homepage from 2 to 3 -- we have more projects now, yay! and three looks nicer.
- Provides basic responsive code for splash and 'Code for Tucson' words
- Fixes visual bug in splash where a white bar showed up a certain screen sizes
- Adds spacing between subpage title and splash/content