### PR TITLE
Add missing project files

### DIFF
--- a/_projects/city-sdk.md
+++ b/_projects/city-sdk.md
@@ -1,0 +1,11 @@
+---
+title: City SDK
+date: 2015-08-03
+link: https://github.com/CodeForTucson/ndoch-city-sdk
+intro: See our work on
+image: /assets/images/citysdk.png
+lead: Andrew Slattery and Corey Bishop
+contact: "@aslattery"
+---
+
+This project was launched in response to the [City SDK Challenge](http://hackforchange.org/challenges/citysdk/) from Code for America's _Hack For Change_ initiative. Our goal is to develop an open-source web application to allow local leaders, agencies, and citizens to easily cross-examine data from federal, state, county, and city sources. One example we built was a tool to compare the locations of farmer's markets against the average household income of various regions in the Tucson metro area, illustrating potential food deserts.

--- a/_projects/code-across-2015.md
+++ b/_projects/code-across-2015.md
@@ -1,0 +1,11 @@
+---
+title: CodeAcross 2015
+date: 2015-01-13
+link: https://www.eventbrite.com/e/codeacross-2015-tickets-15321194104
+intro: Register here for
+image: /assets/images/code-across-400.jpg
+lead: Michelle Hertzfeld
+contact: mherzfeld@gmail.com
+---
+
+A weekend of simultaneous, coordinated events that coincides with Code for America 2015 Fellows last weekend of residence and International Open Data Day. This is the fourth annual CodeAcross event. Code for Tucson is hosting a Feb 21 Saturday event at CoLab. More details to come!

--- a/_projects/community-calendar.md
+++ b/_projects/community-calendar.md
@@ -1,0 +1,11 @@
+---
+title: Community Calendar
+date: 2015-03-30
+link: https://github.com/CodeForTucson/community-calendar
+intro: See our work on
+image: /assets/images/mark_rectangle_400.png
+lead: Michelle Hertzfeld
+contact: mherzfeld@gmail.com
+---
+
+Based on feedback and suggestions from community members, Tucson would really love to see 'One Calendar to Rule Them All.' We're working to creatively solve the distributed community events problem (web scraping, Elasticsearch and intuitive UI, anyone?).

--- a/_projects/my-representatives.md
+++ b/_projects/my-representatives.md
@@ -1,0 +1,11 @@
+---
+title: My Representatives
+date: 2015-08-02
+link: http://codefortucson.github.io/myreps/
+intro: See our work on
+image: /assets/images/myreps.png
+lead: Chris Elsner
+contact: mherzfeld@gmail.com
+---
+
+My Representatives is the fastest and easiest way to find out who is representing you at every level of government. Simply enter your street address and zip code to see who your elected officials are categorized according to the level of government at which they serve.

--- a/_projects/nat-day-of-civic-hacking-2015.md
+++ b/_projects/nat-day-of-civic-hacking-2015.md
@@ -1,0 +1,11 @@
+---
+title: National Day of Civic Hacking 2015
+date: 2015-05-05
+link: http://www.meetup.com/Code-for-Tucson/events/222338265/
+intro: Register here for the
+image: /assets/images/civic-hack-day-2015.png
+lead: Michelle Hertzfeld
+contact: mherzfeld@gmail.com
+---
+
+Code for Tucson invites **you** to the National Day of Civic Hacking! Thousands of people from across the United States will come together to build using publicly-released data, technology, and design processes to improve our communities and the governments that serve them. Anyone can participate; you don’t have to be an expert in technology, you just have to care about your neighborhood and community.


### PR DESCRIPTION
In #66 we pushed the latest batch of changes out to the production
`github-pages` branch, but all the projects disappeared. This was not a
problem with the collections interface, but a problem between the
keyboard and chair.

In a dicey `git` messup, I left the entire new `_projects` directory out
of the commit and thus although the project collection existed in
production, it had no data members.

Those who were responsible for this mishap have been sacked.

cc: @meiqimichelle 