### PR TITLE
Setup Google Analytics and tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,8 @@ owner:
   # For Google Authorship https://plus.google.com/authorship
   google_plus:
 
-google_analytics:
+google_container_id: "GTM-NWHWNQ"
+google_analytics: "UA-75440152-1"
 google_verify:
 
 sass:

--- a/_includes/google_tracking.html
+++ b/_includes/google_tracking.html
@@ -1,0 +1,9 @@
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ site.google_container_id }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ site.google_container_id }}');</script>
+<!-- End Google Tag Manager -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,13 +3,14 @@
   <head>
 
     {% include head.html %}
-    
+
   </head>
 
   <body>
+    {% include google_tracking.html %}
 
     {% include navbar.html %}
-    
+
     {{ content }}
 
     {% include footer.html %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -7,6 +7,7 @@
   </head>
 
   <body>
+    {% include google_tracking.html %}
 
     {% include navbar.html %}
 

--- a/_layouts/subpage.html
+++ b/_layouts/subpage.html
@@ -7,6 +7,7 @@
   </head>
 
   <body>
+    {% include google_tracking.html %}
 
     {% include navbar.html %}
 

--- a/docs/Tracking.md
+++ b/docs/Tracking.md
@@ -1,0 +1,17 @@
+# Analytics and Tracking
+
+This site uses [Google Tag Manager](https://tagmanager.google.com/) to manage the addition, modification, and removal of tracking _tags_. Each tag specifies a particular metric or behavior for the site such as tracking with Google Analytics, running a campaign with Google AdWords, or one of many other Google services.
+
+Although we could setup Google Analytics without using the Tag Manager, by using this product we can make complicated behaviors and changes through the online dashboard without touching the code for this site. This is particularly useful when wanting to do things like only triggering on a given page or click event.
+
+The fetching code **must** appear right under the `<body>` opening tag and can be found in `_includes/google_tracking.html`. It loads the container id stored in `config.yml` which was created from within the Google Tag Manager [admin panel](https://tagmanager.google.com/#/admin/).
+
+> Although the Google Analytics tracking code is also stored in `config.yml`, it is not used directly by the code for this site - it lives there as a reference only.
+
+## Reviewing the Metrics
+
+Login to the [Google Analytics Reporting screen](https://analytics.google.com/analytics/web/) to review the Analytics data.
+
+## Note on Authentication
+
+All access to any of the Google services must be authenticated with the Code for Tucson Google account. If you need the credentials but do not have them, please contact one of the brigade organizers.


### PR DESCRIPTION
Resolves #3

Adds the appropriate snippet to load Google tracking services in the
website configured to the Code for Tucson Google account.

Uses the [Google Tag Manager](https://tagmanager.google.com/) to
administer the creation, modification, and removal of _tags_ such as
Google Analytics. Props to @dtwen for the suggestion against directly
embedding the analytics code and instead to use the tag manager.

Adds a basic page documenting the accounts and administrative process
for the analytics information.

cc: @meiqimichelle 