### PR TITLE
WIP: Creates new focus pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ markdown: kramdown
 permalinks: pretty
 
 collections:
+   - contributor_roles
    - projects
 
 owner:

--- a/_contributor_roles/designer.md
+++ b/_contributor_roles/designer.md
@@ -1,0 +1,8 @@
+---
+title: Designer
+skills:
+ - graphic design
+ - CSS/page layout
+---
+
+We need you to help us figure out _what_ to make.

--- a/_contributor_roles/developer.md
+++ b/_contributor_roles/developer.md
@@ -1,0 +1,9 @@
+---
+title: Developer
+skills:
+ - programming
+ - system administration
+ - product deployment
+---
+
+We need developers to turn our ideas into maintainable projects.

--- a/_contributor_roles/organizer.md
+++ b/_contributor_roles/organizer.md
@@ -1,0 +1,8 @@
+---
+title: Organizer
+skills:
+ - project management
+ - issue prioritization
+---
+
+We need you to help keep us focused and moving forward.

--- a/_contributor_roles/storyteller.md
+++ b/_contributor_roles/storyteller.md
@@ -1,0 +1,8 @@
+---
+title: Storyteller
+skills:
+  - journalism
+  - content generation
+---
+
+We need you to figure out what we should say and how we should say it.

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -21,6 +21,8 @@
             <li {% if page.slug == 'code-of-conduct' %}{{ activeClass }}{% endif %}><a href="/code-of-conduct/">Code of Conduct</a></li>
           </ul>
         </li>
+        <li {% if page.slug == 'current-focus' %}{{ activeClass }}{% endif %}><a href="/current-focus/">What are we doing?</a></li>
+        <li {% if page.slug == 'how-can-I-help' %}{{ activeClass }}{% endif %}><a href="/how-can-I-help/">How can I help?</a></li>
         <li {% if page.slug == 'calendar' %}{{ activeClass }}{% endif %}><a href="http://www.meetup.com/Code-for-Tucson/" target="_blank">Calendar</a></li>
         <li {% if page.slug == 'talk' %}{{ activeClass }}{% endif %}><a href="http://www.meetup.com/Code-for-Tucson/messages/boards/" target="_blank">Talk</a></li>
         <li {% if page.slug == 'projects' %}{{ activeClass }}{% endif %}><a href="/projects/">Projects</a></li>

--- a/pages/current-focus.md
+++ b/pages/current-focus.md
@@ -1,0 +1,26 @@
+---
+layout: subpage
+title: What are we doing?
+permalink: /current-focus/
+slug: current-focus
+---
+
+<div class="col-lg-10">
+We are currently emphasizing two different projects: Communityshare and
+an ongoing effort to organize educational hackathons in the Tucson area.
+
+## Communityshare
+
+Matches specialists and learning opportunities with students and classrooms.
+
+### Current Needs
+ - Simplify the developer experience to lower the barrier-to-entry for new contributors.
+ - Identify and organize usability and functionality issues in [GitHub](github.com/communityshare/communityshare/issues).
+ - Document the existing code structure and architecture.
+
+## Local Education
+
+Organizing civic hackathons and organizing events to educate and inspire
+the next generation of programmers.
+
+</div>

--- a/pages/how-can-I-help.html
+++ b/pages/how-can-I-help.html
@@ -1,0 +1,16 @@
+---
+layout: subpage
+title: How can I help?
+permalink: /how-can-I-help/
+slug: how-can-I-help
+---
+
+<div class="col-lg-10">
+{% assign roles = site.contributor_roles | sort: 'title' %}
+{% for role in roles %}
+<div>
+  <h2>{{ role.title }}</h2>
+  <div>{{ role.content }}</div>
+</div>
+{% endfor %}
+</div>


### PR DESCRIPTION
Related to:
- #65 - Visual design reboot
- #63 - Content reboot

Addresses desire to emphasize Communityshare and our educational
activities. By creating the two new pages in this PR, we should be able
to provide that empasis by giving first-class content and
discoverability to these projects and also by enumerating ways people
can jump in and contribute to them.
