### PR TITLE
Emphasize Communityshare on homepage project list

### DIFF
--- a/_includes/components/project-summary.html
+++ b/_includes/components/project-summary.html
@@ -1,0 +1,15 @@
+<article class="projects row">
+
+  <div class="col-lg-4">
+    <img {% if include.project.image %} src="{{ site.baseurl }}{{ include.project.image }}"{% else %}src="{{ site.baseurl }}/assets/images/captain.png"{% endif %} alt="{{ include.project.project }}">
+  </div>
+
+  <div class="col-lg-8">
+    <h1>{{ include.project.title }}</h1>
+    <p>Project Lead: {% if include.project.lead %}{{ include.project.lead }}{% else %}Coming soon!{% endif %}</p>
+    <p>Project Contact: {% if include.project.contact %}{{ include.project.contact }}{% else %}Coming soon!{% endif %}</p>
+    <p>{% if include.project.content %}{{ include.project.content }}{% else %}Coming soon!{% endif %}</p>
+    <p><a class="github-url" href="{{ include.project.link }}"> {{ include.project.intro }} {{ include.project.title }}! &#8594;</a></p>
+  </div>
+
+</article>

--- a/_projects/community-share.md
+++ b/_projects/community-share.md
@@ -4,7 +4,7 @@ date: 2015-06-01
 link: https://github.com/communityshare/communityshare
 intro: Come help with
 image: /assets/images/communityshare.png
-lead: Josh Schachter & Ben Reynwar
+lead: Ben Reynwar
 contact: <a href="http://www.communityshare.us/contact/" target="_blank">Community Share Contact Page</a>
 ---
-Community Share is a project to connect educators and professionals with the goal of "Inspiring our next generation of learners & leaders." Volunteer your time with a local classroom or find professionals in fields related to your lessons that can help engage your students.
+Community Share is a project to connect educators and professionals with the goal of _"Inspiring our next generation of learners & leaders."_ Volunteer your time with a local classroom or find professionals in fields related to your lessons that can help engage your students.

--- a/_projects/community-share.md
+++ b/_projects/community-share.md
@@ -4,7 +4,7 @@ date: 2015-06-01
 link: https://github.com/communityshare/communityshare
 intro: Come help with
 image: /assets/images/communityshare.png
-lead: Ben Reynwar
+lead: Kristin Wisneski-Blum, Ben Reynwar & Josh Schachter
 contact: <a href="http://www.communityshare.us/contact/" target="_blank">Community Share Contact Page</a>
 ---
 Community Share is a project to connect educators and professionals with the goal of _"Inspiring our next generation of learners & leaders."_ Volunteer your time with a local classroom or find professionals in fields related to your lessons that can help engage your students.

--- a/pages/index.html
+++ b/pages/index.html
@@ -47,23 +47,25 @@ slug: home
 		<h2 class="blackish">what we're doing</h2>
 		<p class='lead'>Code for Tucson creates tools, information, and experiences that serve the Old Pueblo. <br/>See a sample of our projects below, or <a href="/projects/">browse the complete list here.</a> You are welcome to dive right in!</p>
 
+		{% comment %}
+			Show three recent projects, but bump the Communityshare
+			project to the top of the list. We _could_ have used a
+			where expression in Jekyll, but that support was added
+			in version 3.2.0 and GitHub still runs 3.1.6 at the time
+			of this writing. See https://pages.github.com/versions/
+		{% endcomment %}
 		{% assign project_list = site.projects | sort: 'date' | reverse %}
-		{% for project in project_list limit:3 %}
-	      <article class="projects row">
-
-	      	<div class="col-lg-4">
-		        <img {% if project.image %} src="{{ site.baseurl }}{{ project.image }}"{% else %}src="{{ site.baseurl }}/assets/images/captain.png"{% endif %} alt="{{project.project}}">
-		      </div>
-
-					<div class="col-lg-8">
-		        <h1>{{project.title}}</h1>
-		        <p>Project Lead: {% if project.lead %}{{ project.lead }}{% else %}Coming soon!{% endif %}</p>
-		        <p>Project Contact: {% if project.contact %}{{ project.contact }}{% else %}Coming soon!{% endif %}</p>
-		        <p>{% if project.content %}{{ project.content }}{% else %}Coming soon!{% endif %}</p>
-		        <p><a class="github-url" href="{{project.link}}"> {{ project.intro }} {{ project.title }}! &#8594;</a></p>
-		      </div>
-
-	      </article>
+		{% for project in project_list %}
+			{% if 'Community Share' != project.title %}
+				{% continue %}
+			{% endif %}
+			{% include components/project-summary.html project=project %}
+		{% endfor %}
+		{% for project in project_list limit:2 %}
+			{% if 'Community Share' == project.title %}
+				{% continue %}
+			{% endif %}
+			{% include components/project-summary.html project=project %}
 	  {% endfor %}
 
 	</div>

--- a/pages/projects.html
+++ b/pages/projects.html
@@ -8,20 +8,6 @@ slug: projects
 <div class="col-lg-10">
 	{% assign project_list = site.projects | sort: 'date' | reverse %}
 	{% for project in project_list %}
-      <article class="projects row">
-
-      	<div class="col-lg-4">
-        	<img {% if project.image %} src="{{ site.baseurl }}{{ project.image }}"{% else %}src="{{ site.baseurl }}/assets/images/captain.png"{% endif %} alt="{{project.project}}">
-        </div>
-
-        <div class="col-lg-8">
-	        <h1>{{project.title}}</h1>
-	        <p>Project Lead: {% if project.lead %}{{ project.lead }}{% else %}Coming soon!{% endif %}</p>
-	        <p>Project Contact: {% if project.contact %}{{ project.contact }}{% else %}Coming soon!{% endif %}</p>
-	        <p>{% if project.content %}{{ project.content }}{% else %}Coming soon!{% endif %}</p>
-	        <p><a class="github-url" href="{{project.link}}"> {{ project.intro }} {{ project.title }}! &#8594;</a></p>
-	      </div>
-
-      </article>
-    {% endfor %}
+		{% include components/project-summary.html project=project %}
+  {% endfor %}
 </div>


### PR DESCRIPTION
Previously, we were simply grabbing the three most-recent projects
listed by their project date and displaying them on the home page.

This patch makes sure that the Communityshare project is displayed in
that list and also that it appears first. In order to support this
effort, I have refactored the HTML of the project row into a separate
`_include` file to try and make the logic of the display easier.

**Testing**
Compare the homepage on the master branch at [codefortucson.org](codefortucson.org) with the local version. In the master branch, the Communityshare project doesn't make the short list of projects we're working on. In the local branch, it should appear at the top of the list.

cc: @meiqimichelle 