### PR TITLE
Add Slack integration: active users and invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Code For Tucson Website
 =======================
 
+[![Slack Status](https://codefortucson-slackin.herokuapp.com/badge.svg)](http://codefortucson.slack.com)
+
 This is the repository for the website for Code for Tucson, the Tucson chapter of the Code for America Brigade program. It is based on the website for [Code for DC](http://www.codefordc.org).
 
 This site is built on Github Pages, which uses [Jekyll](http://jekyllrb.com/) as a templating language.

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,8 @@ google_container_id: "GTM-NWHWNQ"
 google_analytics: "UA-75440152-1"
 google_verify:
 
+slackin_url: 'http://codefortucson-slackin.herokuapp.com/slackin.js?large'
+
 sass:
   sass_dir: assets/_sass
 

--- a/docs/Slack-Integration.md
+++ b/docs/Slack-Integration.md
@@ -1,0 +1,37 @@
+# Slack Integration
+
+On the front page of the site there is a button to click on
+which shows the current number of active users in the Slack
+team and it also offers an invite button so that people can
+join our Slack group without needing to go through a manual
+invitation process.
+
+## How does it work?
+
+The integration relies on [Slackin](https://github.com/rauchg/slackin),
+which injects an `iframe` into the page to provide the button
+and invitation form.
+
+Slackin relies on a running server, which we have deployed on
+[Heroku](https://dashboard.heroku.com/apps/codefortucson-slackin).
+If you do not have access to the Heroku dashboard and need it,
+please request access from one of the brigade organizers.
+
+The Heroku app relies on two environment variables to operate properly.
+
+```
+SLACK_API_TOKEN=my-api-token-here
+SLACK_SUBDOMAIN=codefortucson
+```
+
+The Slack API token needs to be associated with a Slack account
+with administrative access, otherwise no invites will be sent.
+You can generate a "test token" on [Slack's API page](https://api.slack.com/docs/oauth-test-tokens).
+
+## Integration
+
+Because we are requesting `slackin` remotely, we need to keep the
+following URLs up to date.
+
+ - In `config.yml`, the `slackin_url` variable
+ - In `README.md`, the SVG icon url at the top

--- a/pages/index.html
+++ b/pages/index.html
@@ -31,6 +31,7 @@ slug: home
 			<p>An open conversation online about Tucson, what we're doing now, and what's next.
 			</p>
 			<p><a href="http://www.meetup.com/Code-for-Tucson/messages/boards/">Learn and share &raquo;</a></p>
+			<script async defer src="{{ site.slackin_url }}"></script>
     </div>
 
 		<div class="col-lg-4">


### PR DESCRIPTION
Resolves #79

Previously, there was no information on the Code for Tucson website
concerning our Slack team.

This PR adds a new Slack integration via
[slackin](http://github.com/rauchg/slackin) on the front page and
also via an SVG icon on the GitHub README.

**Before**
![screen shot 2016-07-20 at 12 56 10 am](https://cloud.githubusercontent.com/assets/5431237/16979221/ca0573a4-4e14-11e6-87bd-022651a236f4.png)

**After**
![screen shot 2016-07-20 at 12 55 53 am](https://cloud.githubusercontent.com/assets/5431237/16979235/d5cf5c0e-4e14-11e6-8a31-59fab1a333d2.png)

**with invite dialog open**
![screen shot 2016-07-20 at 12 55 57 am](https://cloud.githubusercontent.com/assets/5431237/16979225/ccae1b9c-4e14-11e6-8d1b-a98d908ec5e8.png)

**Notes**
- This introduces some new JS based on an external service. Currently it's running on a personal Heroku instance (free) and we can easily add some other C4T members to that app. _If_ that app were to crash for some reason, however, this button simply wouldn't load. I do not believe that there would be any indication in the browser that things failed - it should rather simply fail to appear.
- I added an SVG icon to the README for fun because it's there and we can, but we don't have to if we don't want to :wink:

cc: @meiqimichelle 
