### PR TITLE
Fix for Issue #88

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
 
 	<div class="col-lg-6">
 		<img src="{{ site.baseurl }}/{{ site.img_dir }}/cfa_logo_greyscale.png" alt="Code for America" />
-		<p>Code for America is a non-partisan, non-political organization working to create low-risk settings for innovation between citizens and government. <a href="http://codeforamerica.org/" target="_blank">Learn more</a> about Code for America's mission and its Fellowship, Brigade, Accelerator, Peer Network and Code for All programs. <a href="https://github.com/codeforamerica/codeofconduct">Code of Conduct</a>.</p>
+		<p>Code for America is a non-partisan, non-political organization working to create low-risk settings for innovation between citizens and government. <a href="http://codeforamerica.org/" target="_blank">Learn more</a> about Code for America's mission and its Fellowship, Brigade, Accelerator, Peer Network and Code for All programs. <a href="http://codefortucson.org/code-of-conduct/">Code of Conduct</a>.</p>
 	</div>
 
 	<div class="col-lg-3">


### PR DESCRIPTION
https://github.com/CodeForTucson/codefortucson-site/issues/88

Changed Url in the Footer to point to the local code for Tucson Code of
Conduct instead of the Code for America Code of Conduct url.  Was unable to get docker container up and running so I was unable to "test" the change but it is a straight swap so there should be no issues.